### PR TITLE
fix: update workflow configurations for v3 compatibility and modern Node.js

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Message that will be displayed on users first issue'
-        pr-message: 'Message that will be displayed on users first pull request'
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: 'Message that will be displayed on users first issue'
+        pr_message: 'Message that will be displayed on users first pull request'


### PR DESCRIPTION
## Summary

This PR fixes two CI failures in the react-todos-app:

### 1. Greetings workflow failure
The `actions/first-interaction@v3` action expects snake_case parameter names:
- `repo-token` → `repo_token`
- `issue-message` → `issue_message`
- `pr-message` → `pr_message`

### 2. Deployment workflow failure  
The deployment workflow was using Node 12.x which is incompatible with current project dependencies (react-router@7.x requires Node >=18).

### Changes
- `.github/workflows/greetings.yml`: Fixed action input parameter names
- `.github/workflows/github-pages.yml`: Upgraded Node version from 12.x to 20.x

### Testing
CI runs should pass after these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment tooling to use a newer Node.js runtime for GitHub Pages publishing.
  * Aligned workflow configuration with the expected input format for the welcome/first-interaction automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->