### PR TITLE
fix: migrate useRouteMatch to useLocation in About component

### DIFF
--- a/src/functionBased/pages/About.js
+++ b/src/functionBased/pages/About.js
@@ -1,20 +1,20 @@
 import React from 'react'
-import { Link, useRouteMatch, Route } from "react-router-dom"
+import { Link, useLocation, Route } from "react-router-dom"
 import SinglePage from './SinglePage'
 
 const About = () => {
-  const { url, path } = useRouteMatch()
+  const { pathname } = useLocation()
   return (
     <div className="about__content">
       <ul className="about__list">
         <li>
-          <Link to={`${url}/about-app`}>About App</Link>
+          <Link to={`${pathname}/about-app`}>About App</Link>
         </li>
         <li>
-          <Link to={`${url}/about-author`}>About Author</Link>
+          <Link to={`${pathname}/about-author`}>About Author</Link>
         </li>
       </ul>
-      <Route path={`${path}/:slug`}>
+      <Route path={`${pathname}/:slug`}>
         <SinglePage />
       </Route>
     </div>


### PR DESCRIPTION
## Summary

Migrate from deprecated `useRouteMatch` (removed in react-router-dom v6+) to `useLocation` hook.

## Problem

The CI/CD deployment was failing with:


The About.js component still used the deprecated `useRouteMatch` hook that was removed in react-router-dom v6.

## Solution

Replace `useRouteMatch` with `useLocation` and use `pathname` directly.

```diff
- import { Link, useRouteMatch, Route } from "react-router-dom"
- const { url, path } = useRouteMatch()
+ import { Link, useLocation, Route } from "react-router-dom"
+ const { pathname } = useLocation()
```

## Testing

- [x] Build successful
- [x] No ESLint warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated About page navigation to use the current page path, improving link accuracy and routing behavior.
  * Fixed dynamic About subpage routes so page links resolve correctly in the latest routing setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->